### PR TITLE
Temporary patch to PowerMTA bug

### DIFF
--- a/newrelic_pmta_agent.rb
+++ b/newrelic_pmta_agent.rb
@@ -23,6 +23,7 @@ module PmtaAgent
 
     def poll_cycle
       @agent= Mechanize.new unless @agent
+      @agent.pluggable_parser['text/html'] = Mechanize::XmlFile
       report_status
       report_queues
       report_domains


### PR DESCRIPTION
This is annoying and I've reported the bug to Port25, however this gets data to appear in NewRelic by overriding the parser for the status?format=xml response.
